### PR TITLE
131 android testのハードコードを修正する

### DIFF
--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/InputKeyWordContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/InputKeyWordContentTest.kt
@@ -1,14 +1,16 @@
 package com.example.gourmetsearchercompose
 
+import android.content.Context
 import androidx.compose.ui.focus.FocusRequester
-
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.InputKeyWordContent
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.keywordhistory.KeyWordHistoryList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.range.RangeList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.textfield.SearchTextField
+import com.example.gourmetsearchercompose.utils.UITestHelper
 import kotlinx.collections.immutable.persistentListOf
 import org.junit.Rule
 import org.junit.Test
@@ -17,13 +19,19 @@ class InputKeyWordContentTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val mockHistoryList = persistentListOf("History 1", "History 2")
+
+    private val testHelper = UITestHelper(composeTestRule)
+
     @Test
     fun testInputKeyWordContent_emptyInput() {
         composeTestRule.setContent {
             InputKeyWordContent(
                 inputText = "",
                 focusRequester = FocusRequester(),
-                historyList = persistentListOf("History 1", "History 2"),
+                historyList = mockHistoryList,
                 onInputTextChange = {},
                 onClearHistory = {},
                 onRangeSelect = {}
@@ -31,9 +39,13 @@ class InputKeyWordContentTest {
         }
 
         composeTestRule.onNodeWithTag("SearchBar").assertExists()
-        composeTestRule.onNodeWithText("History 1").assertExists()
-        composeTestRule.onNodeWithText("History 2").assertExists()
-        composeTestRule.onNodeWithText("キーワードをクリア").assertExists()
+        for (mockHistory in mockHistoryList) {
+            testHelper.assertTextsDisplayed(mockHistory)
+        }
+
+        //キーワードをクリア
+        val clearLabel = context.getString(R.string.input_keyword_key_word_clear)
+        testHelper.assertTextsDisplayed(clearLabel)
     }
 
     @Test
@@ -50,7 +62,8 @@ class InputKeyWordContentTest {
         }
 
         composeTestRule.onNodeWithTag("SearchBar").assertExists()
-        composeTestRule.onNodeWithText("検索半径を選択して検索").assertExists()
+        val rangeLabel = context.getString(R.string.input_keyword_select_range_explanation)
+        testHelper.assertTextsDisplayed(rangeLabel)
     }
 
     @Test
@@ -65,23 +78,31 @@ class InputKeyWordContentTest {
         }
 
         composeTestRule.onNodeWithTag("searchTextField").assertExists()
-        composeTestRule.onNodeWithText(testQuery).assertExists()
-        composeTestRule.onNodeWithText("キーワードを入力").assertExists()
+        //キーワードを入力
+        val hint = context.getString(R.string.input_keyword_search_input_hint)
+        testHelper.assertTextsDisplayed(
+            testQuery,
+            hint
+        )
     }
 
     @Test
     fun testKeyWordHistoryList() {
         composeTestRule.setContent {
             KeyWordHistoryList(
-                historyList = persistentListOf("History 1", "History 2"),
+                historyList = mockHistoryList,
                 onItemClick = {},
                 onClearClick = {}
             )
         }
 
-        composeTestRule.onNodeWithText("History 1").assertExists()
-        composeTestRule.onNodeWithText("History 2").assertExists()
-        composeTestRule.onNodeWithText("キーワードをクリア").assertExists()
+        for (mockHistory in mockHistoryList) {
+            composeTestRule.onNodeWithText(mockHistory).assertExists()
+        }
+
+        //キーワードをクリア
+        val clearLabel = context.getString(R.string.input_keyword_key_word_clear)
+        testHelper.assertTextsDisplayed(clearLabel)
     }
 
     @Test
@@ -92,11 +113,14 @@ class InputKeyWordContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("検索半径を選択して検索").assertExists()
-        composeTestRule.onNodeWithText("300m").assertExists()
-        composeTestRule.onNodeWithText("500m").assertExists()
-        composeTestRule.onNodeWithText("1000m").assertExists()
-        composeTestRule.onNodeWithText("2000m").assertExists()
-        composeTestRule.onNodeWithText("3000m").assertExists()
+        //検索半径を選択して検索
+        val rangeLabel = context.getString(R.string.input_keyword_select_range_explanation)
+        testHelper.assertTextsDisplayed(rangeLabel)
+
+        val rangeArray = context.resources.getStringArray(R.array.input_keyword_range_array)
+        val meter = context.getString(R.string.input_keyword_meter)
+        for (range in rangeArray) {
+            testHelper.assertTextsDisplayed(range + meter)
+        }
     }
 }

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantDetailContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantDetailContentTest.kt
@@ -1,16 +1,21 @@
 package com.example.gourmetsearchercompose
 
-import androidx.compose.ui.test.assertIsDisplayed
+import android.content.Context
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
 import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
 import com.example.gourmetsearchercompose.ui.screen.restaurantdetail.component.RestaurantDetailContent
+import com.example.gourmetsearchercompose.utils.UITestHelper
 import org.junit.Rule
 import org.junit.Test
 
 class RestaurantDetailContentTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val testHelper = UITestHelper(composeTestRule)
 
     @Test
     fun testRestaurantDetailContent() {
@@ -22,28 +27,31 @@ class RestaurantDetailContentTest {
             )
         }
 
-        // レストラン名のテスト
-        composeTestRule.onNodeWithText(sampleRestaurantData.name).assertIsDisplayed()
-            .assertIsDisplayed()
+        // レストランの情報が表示されていることを確認
+        with(sampleRestaurantData) {
+            testHelper.assertTextsDisplayed(
+                name,
+                genre.name,
+                budget.name,
+                open,
+                address,
+                access,
+                close
+            )
+        }
 
-        // 主要情報のテスト
-        composeTestRule.onNodeWithText(sampleRestaurantData.genre.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantData.budget.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantData.open)
-            .assertIsDisplayed()
-
-        // 詳細情報のテスト
-        composeTestRule.onNodeWithText("住所").assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantData.address)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("アクセス").assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantData.access)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("休業日")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantData.close).assertIsDisplayed()
-
+        // タイトルのテスト
+        val addressTitle = context.getString(R.string.restaurant_detail_address)
+        val accessTitle = context.getString(R.string.restaurant_detail_access)
+        val closedDaysTitle = context.getString(R.string.restaurant_detail_closed_days)
         // ホットペッパーボタンのテスト
-        composeTestRule.onNodeWithText("HotPepperへ").assertIsDisplayed()
+        val hotPepperButton = context.getString(R.string.restaurant_detail_hot_pepper)
+
+        testHelper.assertTextsDisplayed(
+            addressTitle,
+            accessTitle,
+            closedDaysTitle,
+            hotPepperButton
+        )
     }
 }

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantListContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantListContentTest.kt
@@ -1,22 +1,28 @@
 package com.example.gourmetsearchercompose
 
+import android.content.Context
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
 import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.state.SearchState
 import com.example.gourmetsearchercompose.ui.screen.restaurantlist.component.RestaurantInfo
 import com.example.gourmetsearchercompose.ui.screen.restaurantlist.component.RestaurantItem
 import com.example.gourmetsearchercompose.ui.screen.restaurantlist.component.RestaurantListContent
 import com.example.gourmetsearchercompose.ui.screen.restaurantlist.component.RestaurantRow
+import com.example.gourmetsearchercompose.utils.UITestHelper
 import org.junit.Rule
 import org.junit.Test
 
 class RestaurantListContentTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val testHelper = UITestHelper(composeTestRule)
 
     @Test
     fun testRestaurantListContent_Success() {
@@ -30,8 +36,9 @@ class RestaurantListContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[1].name).assertIsDisplayed()
+        for (restaurant in sampleRestaurantList) {
+            testHelper.assertTextsDisplayed(restaurant.name)
+        }
     }
 
     @Test
@@ -46,7 +53,8 @@ class RestaurantListContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("検索結果がありませんでした").assertIsDisplayed()
+        val emptyResultMessage = context.getString(R.string.restaurant_list_empty_result_message)
+        testHelper.assertTextsDisplayed(emptyResultMessage)
     }
 
     @Test
@@ -61,8 +69,13 @@ class RestaurantListContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("ネットワークエラーが発生しました").assertIsDisplayed()
-        composeTestRule.onNodeWithText("リトライ").assertIsDisplayed()
+        val networkErrorMessage = context.getString(R.string.restaurant_list_network_error_message)
+        val retryLabel = context.getString(R.string.common_retry)
+
+        testHelper.assertTextsDisplayed(
+            networkErrorMessage,
+            retryLabel
+        )
     }
 
     @Test
@@ -74,8 +87,9 @@ class RestaurantListContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[1].name).assertIsDisplayed()
+        for (restaurant in sampleRestaurantList) {
+            testHelper.assertTextsDisplayed(restaurant.name)
+        }
     }
 
     @Test
@@ -88,14 +102,18 @@ class RestaurantListContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("${sampleRestaurantList[0].smallArea.name}[${sampleRestaurantList[0].largeArea.name}]")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].genre.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].budget.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].access).assertIsDisplayed()
 
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].name).performClick()
+        with(sampleRestaurantList[0]) {
+            testHelper.assertTextsDisplayed(
+                name,
+                "${smallArea.name}[${largeArea.name}]",
+                genre.name,
+                budget.name,
+                access
+            )
+
+            composeTestRule.onNodeWithText(name).performClick()
+        }
         assert(clicked.value)
     }
 
@@ -105,11 +123,14 @@ class RestaurantListContentTest {
             RestaurantInfo(restaurant = sampleRestaurantList[0])
         }
 
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("${sampleRestaurantList[0].smallArea.name}[${sampleRestaurantList[0].largeArea.name}]")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].genre.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].budget.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(sampleRestaurantList[0].access).assertIsDisplayed()
+        with(sampleRestaurantList[0]) {
+            testHelper.assertTextsDisplayed(
+                name,
+                "${smallArea.name}[${largeArea.name}]",
+                genre.name,
+                budget.name,
+                access
+            )
+        }
     }
 }

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/SearchLocationContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/SearchLocationContentTest.kt
@@ -1,11 +1,12 @@
 package com.example.gourmetsearchercompose
 
-import androidx.compose.ui.test.assertIsDisplayed
+import android.content.Context
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
-import com.example.gourmetsearchercompose.state.LocationSearchState
+import androidx.test.core.app.ApplicationProvider
 import com.example.gourmetsearchercompose.mock.FakePermissionState
+import com.example.gourmetsearchercompose.state.LocationSearchState
 import com.example.gourmetsearchercompose.ui.screen.seachlocation.component.SearchLocationContent
+import com.example.gourmetsearchercompose.utils.UITestHelper
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import org.junit.Rule
@@ -15,6 +16,10 @@ import org.junit.Test
 class SearchLocationContentTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val testHelper = UITestHelper(composeTestRule)
 
     @Test
     fun testSearchLocationContent_Error_PermissionGranted() {
@@ -27,9 +32,15 @@ class SearchLocationContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("位置情報を取得できませんでした").assertIsDisplayed()
-        composeTestRule.onNodeWithText("リトライ").assertIsDisplayed()
-        composeTestRule.onNodeWithText("設定を開く").assertIsDisplayed()
+        val errorMessage = context.getString(R.string.search_location_error_message)
+        val retryLabel = context.getString(R.string.common_retry)
+        val settingLabel = context.getString(R.string.search_location_setting)
+
+        testHelper.assertTextsDisplayed(
+            errorMessage,
+            retryLabel,
+            settingLabel
+        )
     }
 
     @Test
@@ -48,9 +59,16 @@ class SearchLocationContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("位置情報が許可されていません").assertIsDisplayed()
-        composeTestRule.onNodeWithText("リトライ").assertIsDisplayed()
-        composeTestRule.onNodeWithText("設定を開く").assertIsDisplayed()
+
+        val errorMessage = context.getString(R.string.search_location_permission_denied_message)
+        val retryLabel = context.getString(R.string.common_retry)
+        val settingLabel = context.getString(R.string.search_location_setting)
+
+        testHelper.assertTextsDisplayed(
+            errorMessage,
+            retryLabel,
+            settingLabel
+        )
     }
 
     @Test
@@ -68,7 +86,13 @@ class SearchLocationContentTest {
             )
         }
 
-        composeTestRule.onNodeWithText("このアプリでは、位置情報を取得するために位置情報パーミッションが必要です").assertIsDisplayed()
-        composeTestRule.onNodeWithText("OK").assertIsDisplayed()
+        val rationalMessage =
+            context.getString(R.string.search_location_permission_required_message)
+        val okLabel = context.getString(R.string.common_ok)
+
+        testHelper.assertTextsDisplayed(
+            rationalMessage,
+            okLabel
+        )
     }
 }

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/utils/UITestHelper.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/utils/UITestHelper.kt
@@ -1,0 +1,14 @@
+package com.example.gourmetsearchercompose.utils
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+
+class UITestHelper(private val composeTestRule: ComposeContentTestRule) {
+
+    fun assertTextsDisplayed(vararg texts: String) {
+        texts.forEach { text ->
+            composeTestRule.onNodeWithText(text).assertIsDisplayed()
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- ISSUE #131 

## 現状の問題点
-  Android Testでハードコードされていた箇所を修正し、メッセージ変更時のメンテナンスを容易にしました。
- UITestHelperを実装し、可読性が低かった箇所を改善しました。

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- UITestの実装
- ハードコードの修正
- withを使ってモックとの検証コードの可読性の向上


## 技術的な詳細（任意）
<!-- 実装に関する技術的な詳細や注意点があれば記載してください -->
- 

## 参考リンク (任意)
- 

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
