### PR TITLE
モックデータを一箇所から使うように変更しました

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     // MockitoJUnitRunner
-    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito)
     testImplementation(libs.junit)
     testImplementation(libs.dagger.hilt.android.testing)
     kspTest(libs.dagger.hilt.android.compiler)
@@ -151,7 +151,6 @@ dependencies {
     androidTestImplementation(libs.dagger.hilt.android.testing)
     kspAndroidTest(libs.dagger.hilt.android.compiler)
 }
-
 detekt {
     parallel = true
     config.setFrom("${rootProject.projectDir}/config/detekt/detekt.yml")

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/InputKeyWordContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/InputKeyWordContentTest.kt
@@ -6,12 +6,14 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.InputKeyWordContent
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.keywordhistory.KeyWordHistoryList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.range.RangeList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.textfield.SearchTextField
 import com.example.gourmetsearchercompose.utils.UITestHelper
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,8 +23,7 @@ class InputKeyWordContentTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    private val mockHistoryList = persistentListOf("History 1", "History 2")
-
+    private val mockHistoryList = sampleHistoryList.toPersistentList()
     private val testHelper = UITestHelper(composeTestRule)
 
     @Test

--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantDetailContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantDetailContentTest.kt
@@ -3,7 +3,7 @@ package com.example.gourmetsearchercompose
 import android.content.Context
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.ui.screen.restaurantdetail.component.RestaurantDetailContent
 import com.example.gourmetsearchercompose.utils.UITestHelper
 import org.junit.Rule
@@ -21,14 +21,14 @@ class RestaurantDetailContentTest {
     fun testRestaurantDetailContent() {
         composeTestRule.setContent {
             RestaurantDetailContent(
-                restaurantData = sampleRestaurantData,
+                restaurantData = sampleRestaurantList[0],
                 onHotPepperClick = {},
                 onMapClick = {}
             )
         }
 
         // レストランの情報が表示されていることを確認
-        with(sampleRestaurantData) {
+        with(sampleRestaurantList[0]) {
             testHelper.assertTextsDisplayed(
                 name,
                 genre.name,

--- a/app/src/main/java/com/example/gourmetsearchercompose/mock/MockRestaurantData.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/mock/MockRestaurantData.kt
@@ -5,6 +5,8 @@ import com.example.gourmetsearchercompose.model.api.GenreData
 import com.example.gourmetsearchercompose.model.api.LargeAreaData
 import com.example.gourmetsearchercompose.model.api.PCData
 import com.example.gourmetsearchercompose.model.api.PhotoData
+import com.example.gourmetsearchercompose.model.api.RestaurantList
+import com.example.gourmetsearchercompose.model.api.Results
 import com.example.gourmetsearchercompose.model.api.Shops
 import com.example.gourmetsearchercompose.model.api.SmallAreaData
 import com.example.gourmetsearchercompose.model.api.Urls
@@ -14,56 +16,49 @@ import kotlinx.collections.immutable.toImmutableList
 
 /**
  * モックレストランデータ
- * @property sampleRestaurantData モックレストランデータ
+ * @property sampleResponseData モックレストランレスポンスデータ
  * @property sampleRestaurantList モックレストランリスト
  * @property sampleEmptyRestaurantList 空のモックレストランリスト
  */
 object MockRestaurantData {
-    val sampleRestaurantData = Shops(
-        "モックレストランデータレストラン1",
-        "大阪府大阪市中央区難波１ - 7",
-        "なんば",
-        LargeAreaData("大阪"),
-        SmallAreaData("大阪難波"),
-        GenreData("居酒屋"),
-        BudgetData("2001～3000 円"),
-        "なんば駅徒歩1分",
-        Urls("http://www.testdata.jp/strJ003785192/?vos=nhppalsa000016"),
-        PhotoData(PCData(l = "http://test.jpg")),
-        "月～金",
-        "なし"
-    ).toDomain()
+    val sampleResponseData =
+        RestaurantList(
+            Results(
+                listOf(
+                    Shops(
+                        "モックレストランデータレストラン1",
+                        "大阪府大阪市中央区難波１ - 7",
+                        "なんば",
+                        LargeAreaData("大阪"),
+                        SmallAreaData("大阪難波"),
+                        GenreData("居酒屋"),
+                        BudgetData("2001～3000 円"),
+                        "なんば駅徒歩1分",
+                        Urls("http://www.testdata.jp/strJ003785192/?vos=nhppalsa000016"),
+                        PhotoData(PCData(l = "http://test.jpg")),
+                        "月～金",
+                        "なし"
+                    ),
+                    Shops(
+                        "モックレストランデータレストラン2",
+                        "大阪府大阪市中央区難波１ - 7",
+                        "なんば",
+                        LargeAreaData("大阪"),
+                        SmallAreaData("大阪難波"),
+                        GenreData("居酒屋"),
+                        BudgetData("2001～3000 円"),
+                        "なんば駅徒歩1分",
+                        Urls("http://www.testdata.jp/strJ003785192/?vos=nhppalsa000016"),
+                        PhotoData(PCData(l = "http://test.jpg")),
+                        "月～金",
+                        "なし"
+                    )
+                ),
+            ),
+        )
 
-    val sampleRestaurantList = listOf(
-        Shops(
-            "モックレストランデータレストラン1",
-            "大阪府大阪市中央区難波１ - 7",
-            "なんば",
-            LargeAreaData("大阪"),
-            SmallAreaData("大阪難波"),
-            GenreData("居酒屋"),
-            BudgetData("2001～3000 円"),
-            "なんば駅徒歩1分",
-            Urls("http://www.testdata.jp/strJ003785192/?vos=nhppalsa000016"),
-            PhotoData(PCData(l = "http://test.jpg")),
-            "月～金",
-            "なし"
-        ).toDomain(),
-        Shops(
-            "モックレストランデータレストラン2",
-            "大阪府大阪市中央区難波１ - 7",
-            "なんば",
-            LargeAreaData("大阪"),
-            SmallAreaData("大阪難波"),
-            GenreData("居酒屋"),
-            BudgetData("2001～3000 円"),
-            "なんば駅徒歩1分",
-            Urls("http://www.testdata.jp/strJ003785192/?vos=nhppalsa000016"),
-            PhotoData(PCData(l = "http://test.jpg")),
-            "月～金",
-            "なし"
-        ).toDomain()
-    ).toImmutableList()
+    val sampleRestaurantList =
+        sampleResponseData.results.shops.map { it.toDomain() }.toImmutableList()
 
     val sampleEmptyRestaurantList = emptyList<ShopsDomain>().toImmutableList()
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/mock/MockRestaurantData.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/mock/MockRestaurantData.kt
@@ -1,5 +1,8 @@
 package com.example.gourmetsearchercompose.mock
 
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleEmptyRestaurantList
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.api.BudgetData
 import com.example.gourmetsearchercompose.model.api.GenreData
 import com.example.gourmetsearchercompose.model.api.LargeAreaData
@@ -13,6 +16,7 @@ import com.example.gourmetsearchercompose.model.api.Urls
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.model.domain.toDomain
 import kotlinx.collections.immutable.toImmutableList
+import retrofit2.Response
 
 /**
  * モックレストランデータ
@@ -56,6 +60,10 @@ object MockRestaurantData {
                 ),
             ),
         )
+
+    val sampleAPIResponse = Response.success(
+        sampleResponseData
+    )
 
     val sampleRestaurantList =
         sampleResponseData.results.shops.map { it.toDomain() }.toImmutableList()

--- a/app/src/main/java/com/example/gourmetsearchercompose/mock/MockSearchTerms.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/mock/MockSearchTerms.kt
@@ -1,13 +1,23 @@
 package com.example.gourmetsearchercompose.mock
 
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
+import com.example.gourmetsearchercompose.model.data.CurrentLocation
+import com.example.gourmetsearchercompose.model.data.SearchTerms
 import kotlinx.collections.immutable.toImmutableList
 
 /**
  * モック検索条件
- * @property keywordHistory キーワード履歴
+ * @property sampleHistoryList キーワード履歴
  * @property KEYWORD キーワード
  */
 object MockSearchTerms {
-    val keywordHistory = listOf("焼肉", "寿司", "ラーメン").toImmutableList()
+    val sampleHistoryList = listOf("item1", "item2", "item3").toImmutableList()
     const val KEYWORD = "焼肉"
+
+    val sampleSearchTerms = SearchTerms(
+        "keyword",
+        CurrentLocation(35.0, 139.0),
+        1
+    )
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/keywordhistory/KeyWordHistoryList.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/keywordhistory/KeyWordHistoryList.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.gourmetsearchercompose.R
-import com.example.gourmetsearchercompose.mock.MockSearchTerms.keywordHistory
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.ui.screen.component.CustomOutlinedButton
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
 import kotlinx.collections.immutable.ImmutableList
@@ -60,7 +60,7 @@ fun KeyWordHistoryList(
 private fun PreviewKeyWordHistoryList() {
     PreviewComponentWrapper {
         KeyWordHistoryList(
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onItemClick = {},
             onClearClick = {}
         )

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/keywordhistory/KeyWordHistoryListContent.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/keywordhistory/KeyWordHistoryListContent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
-import com.example.gourmetsearchercompose.mock.MockSearchTerms.keywordHistory
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.ui.screen.component.IconText
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.InputKeyWordContent
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewWrapper
@@ -63,7 +63,7 @@ private fun RangeListPreview() {
         InputKeyWordContent(
             focusRequester = FocusRequester(),
             inputText = KEYWORD,
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onInputTextChange = {},
             onClearHistory = {},
             onRangeSelect = {}

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/range/RangeListContent.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/inputkeyword/component/range/RangeListContent.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.gourmetsearchercompose.R
-import com.example.gourmetsearchercompose.mock.MockSearchTerms.keywordHistory
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.keywordhistory.KeyWordHistoryList
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
 
@@ -61,7 +61,7 @@ fun RangeListContent(
 private fun PreviewRangeList() {
     PreviewComponentWrapper {
         KeyWordHistoryList(
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onItemClick = {},
             onClearClick = {}
         )

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/preview/InputKeyWordContentPreview.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/preview/InputKeyWordContentPreview.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
-import com.example.gourmetsearchercompose.mock.MockSearchTerms.keywordHistory
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.ui.screen.inputkeyword.component.InputKeyWordContent
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewWrapper
 
@@ -17,7 +17,7 @@ private fun KeyWordListPreview() {
         InputKeyWordContent(
             focusRequester = FocusRequester(),
             inputText = "",
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onInputTextChange = {},
             onClearHistory = {},
             onRangeSelect = {}
@@ -34,7 +34,7 @@ private fun KeyWordListDarkPreview() {
         InputKeyWordContent(
             focusRequester = FocusRequester(),
             inputText = "",
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onInputTextChange = {},
             onClearHistory = {},
             onRangeSelect = {}
@@ -51,7 +51,7 @@ private fun RangeListPreview() {
         InputKeyWordContent(
             focusRequester = FocusRequester(),
             inputText = KEYWORD,
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onInputTextChange = {},
             onClearHistory = {},
             onRangeSelect = {}
@@ -68,7 +68,7 @@ private fun RangeListDarkPreview() {
         InputKeyWordContent(
             focusRequester = FocusRequester(),
             inputText = KEYWORD,
-            historyList = keywordHistory,
+            historyList = sampleHistoryList,
             onInputTextChange = {},
             onClearHistory = {},
             onRangeSelect = {}

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/preview/RestaurantDetailContentPreview.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/preview/RestaurantDetailContentPreview.kt
@@ -2,7 +2,7 @@ package com.example.gourmetsearchercompose.ui.screen.preview
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewWrapper
 import com.example.gourmetsearchercompose.ui.screen.restaurantdetail.RestaurantDetailScreen
 
@@ -13,7 +13,7 @@ import com.example.gourmetsearchercompose.ui.screen.restaurantdetail.RestaurantD
 private fun Preview() {
     PreviewWrapper {
         RestaurantDetailScreen(
-            restaurantData = sampleRestaurantData
+            restaurantData = sampleRestaurantList[0]
         )
     }
 }
@@ -25,7 +25,7 @@ private fun Preview() {
 private fun DarkPreview() {
     PreviewWrapper(darkTheme = true) {
         RestaurantDetailScreen(
-            restaurantData = sampleRestaurantData
+            restaurantData = sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/RestaurantDetailScreen.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/RestaurantDetailScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewWrapper
 import com.example.gourmetsearchercompose.ui.screen.restaurantdetail.component.RestaurantDetailContent
@@ -63,7 +63,7 @@ fun RestaurantDetailScreen(
 private fun RestaurantDetailContentPreview() {
     PreviewWrapper {
         RestaurantDetailScreen(
-            restaurantData = sampleRestaurantData
+            restaurantData = sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/ContentItem.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/ContentItem.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.gourmetsearchercompose.R
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
 
 /**
@@ -56,7 +56,7 @@ private fun PreviewContentItem() {
     PreviewComponentWrapper {
         ContentItem(
             title = R.string.restaurant_detail_closed_days,
-            content = sampleRestaurantData.close,
+            content = sampleRestaurantList[0].close,
             icon = Icons.Default.EventBusy
         )
     }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/DetailChip.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/DetailChip.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.ui.screen.component.IconText
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
 
@@ -48,7 +48,7 @@ private fun PreviewDetailChip() {
     PreviewComponentWrapper {
         DetailChip(
             icon = Icons.Default.AttachMoney,
-            text = sampleRestaurantData.budget.name
+            text = sampleRestaurantList[0].budget.name
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantDetailCard.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantDetailCard.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.gourmetsearchercompose.R
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
 
@@ -65,7 +65,7 @@ fun RestaurantDetailCard(
 private fun PreviewRestaurantDetailCard() {
     PreviewComponentWrapper {
         RestaurantDetailCard(
-            restaurantData = sampleRestaurantData
+            restaurantData = sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantDetailContent.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantDetailContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.gourmetsearchercompose.R
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.ui.screen.component.CustomOutlinedButton
 import com.example.gourmetsearchercompose.ui.screen.component.ImageCard
@@ -72,7 +72,7 @@ fun RestaurantDetailContent(
 private fun RestaurantDetailContentPreview() {
     PreviewWrapper {
         RestaurantDetailScreen(
-            restaurantData = sampleRestaurantData
+            restaurantData = sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantMainInfo.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantdetail/component/RestaurantMainInfo.kt
@@ -73,7 +73,7 @@ fun RestaurantMainInfo(
 private fun PreviewRestaurantMainInfo() {
     PreviewComponentWrapper {
         RestaurantMainInfo(
-            restaurantData = MockRestaurantData.sampleRestaurantData
+            restaurantData = MockRestaurantData.sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantlist/component/RestaurantInfo.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantlist/component/RestaurantInfo.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.ui.screen.component.IconText
 import com.example.gourmetsearchercompose.ui.screen.preview.component.PreviewComponentWrapper
@@ -63,7 +63,7 @@ fun RestaurantInfo(
 private fun PreviewRestaurantInfo() {
     PreviewComponentWrapper {
         RestaurantInfo(
-            restaurant = sampleRestaurantData
+            restaurant = sampleRestaurantList[0]
         )
     }
 }

--- a/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantlist/component/RestaurantItem.kt
+++ b/app/src/main/java/com/example/gourmetsearchercompose/ui/screen/restaurantlist/component/RestaurantItem.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import com.example.gourmetsearchercompose.model.domain.ShopsDomain
 import com.example.gourmetsearchercompose.ui.screen.component.ImageCard
 
@@ -60,7 +60,7 @@ fun RestaurantItem(
 @Composable
 private fun PreviewRestaurantItem() {
     RestaurantItem(
-        restaurant = sampleRestaurantData,
+        restaurant = sampleRestaurantList[0],
         onClick = {}
     )
 }

--- a/app/src/test/java/com/example/gourmetsearchercompose/manager/CacheManagerTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/manager/CacheManagerTest.kt
@@ -1,6 +1,7 @@
 package com.example.gourmetsearchercompose.manager
 
 import android.util.LruCache
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleAPIResponse
 import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
@@ -34,7 +35,7 @@ class CacheManagerTest {
     /** キャッシュにレスポンスが存在する場合のgetメソッドのテスト */
     @Test
     fun testGetCachedResponse() {
-        val mockResponse = Response.success(sampleResponseData)
+        val mockResponse = sampleAPIResponse
         `when`(mockCache[sampleSearchTerms]).thenReturn(mockResponse)
 
         val result = cacheManager.get(sampleSearchTerms)
@@ -55,7 +56,7 @@ class CacheManagerTest {
     /** putメソッドのテスト */
     @Test
     fun testPutResponse() {
-        val mockResponse = Response.success(sampleResponseData)
+        val mockResponse = sampleAPIResponse
 
         cacheManager.put(sampleSearchTerms, mockResponse)
 

--- a/app/src/test/java/com/example/gourmetsearchercompose/manager/CacheManagerTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/manager/CacheManagerTest.kt
@@ -1,16 +1,9 @@
 package com.example.gourmetsearchercompose.manager
 
 import android.util.LruCache
-import com.example.gourmetsearchercompose.model.api.BudgetData
-import com.example.gourmetsearchercompose.model.api.GenreData
-import com.example.gourmetsearchercompose.model.api.LargeAreaData
-import com.example.gourmetsearchercompose.model.api.PCData
-import com.example.gourmetsearchercompose.model.api.PhotoData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
-import com.example.gourmetsearchercompose.model.api.Results
-import com.example.gourmetsearchercompose.model.api.Shops
-import com.example.gourmetsearchercompose.model.api.SmallAreaData
-import com.example.gourmetsearchercompose.model.api.Urls
 import com.example.gourmetsearchercompose.model.data.CurrentLocation
 import com.example.gourmetsearchercompose.model.data.SearchTerms
 import org.junit.Assert.assertEquals
@@ -32,34 +25,6 @@ class CacheManagerTest {
 
     private lateinit var cacheManager: CacheManager
 
-    private val mockSearchTerms = SearchTerms(
-        "keyword",
-        CurrentLocation(35.0, 139.0),
-        1
-    )
-
-    private val mockRestaurantList =
-        RestaurantList(
-            Results(
-                listOf(
-                    Shops(
-                        "Restaurant",
-                        "Address",
-                        "Station",
-                        LargeAreaData("Large Area"),
-                        SmallAreaData("Small Area"),
-                        GenreData("Genre"),
-                        BudgetData("Budget"),
-                        "Access",
-                        Urls("URL"),
-                        PhotoData(PCData("Photo URL")),
-                        "Open",
-                        "Close",
-                    ),
-                ),
-            ),
-        )
-
     /** テスト前の初期化 */
     @Before
     fun setUp() {
@@ -69,10 +34,10 @@ class CacheManagerTest {
     /** キャッシュにレスポンスが存在する場合のgetメソッドのテスト */
     @Test
     fun testGetCachedResponse() {
-        val mockResponse = Response.success(mockRestaurantList)
-        `when`(mockCache[mockSearchTerms]).thenReturn(mockResponse)
+        val mockResponse = Response.success(sampleResponseData)
+        `when`(mockCache[sampleSearchTerms]).thenReturn(mockResponse)
 
-        val result = cacheManager.get(mockSearchTerms)
+        val result = cacheManager.get(sampleSearchTerms)
 
         assertEquals(mockResponse, result)
     }
@@ -80,9 +45,9 @@ class CacheManagerTest {
     /** キャッシュが空の場合のgetメソッドのテスト */
     @Test
     fun testGetEmptyCache() {
-        `when`(mockCache[mockSearchTerms]).thenReturn(null)
+        `when`(mockCache[sampleSearchTerms]).thenReturn(null)
 
-        val result = cacheManager.get(mockSearchTerms)
+        val result = cacheManager.get(sampleSearchTerms)
 
         assertNull(result)
     }
@@ -90,11 +55,11 @@ class CacheManagerTest {
     /** putメソッドのテスト */
     @Test
     fun testPutResponse() {
-        val mockResponse = Response.success(mockRestaurantList)
+        val mockResponse = Response.success(sampleResponseData)
 
-        cacheManager.put(mockSearchTerms, mockResponse)
+        cacheManager.put(sampleSearchTerms, mockResponse)
 
-        verify(mockCache).put(mockSearchTerms, mockResponse)
+        verify(mockCache).put(sampleSearchTerms, mockResponse)
     }
 
     /** 無効な入力でのgetメソッドのテスト */
@@ -111,15 +76,16 @@ class CacheManagerTest {
         val maxSize = 5
         val fullCache = mockCache
         val fullCacheManager = CacheManager(fullCache)
+        val location = sampleSearchTerms.location
 
         repeat(maxSize) { i ->
-            val terms = SearchTerms("keyword$i", CurrentLocation(35.0, 139.0), i)
-            fullCacheManager.put(terms, Response.success(mockRestaurantList))
+            val terms = SearchTerms("keyword$i", location, i)
+            fullCacheManager.put(terms, Response.success(sampleResponseData))
         }
 
-        val newTerms = SearchTerms("newKeyword", CurrentLocation(35.0, 139.0), maxSize)
-        fullCacheManager.put(newTerms, Response.success(mockRestaurantList))
+        val newTerms = SearchTerms("newKeyword", location, maxSize)
+        fullCacheManager.put(newTerms, Response.success(sampleResponseData))
 
-        assertNull(fullCacheManager.get(SearchTerms("keyword0", CurrentLocation(35.0, 139.0), 0)))
+        assertNull(fullCacheManager.get(SearchTerms("keyword0", location, 0)))
     }
 }

--- a/app/src/test/java/com/example/gourmetsearchercompose/manager/PreferencesManagerTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/manager/PreferencesManagerTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -50,21 +51,23 @@ class PreferencesManagerTest {
     @Test
     fun testAddNewToEmpty() =
         runBlocking {
-            preferencesManager.saveHistoryItem("test")
+            val textList = listOf("test")
+            preferencesManager.saveHistoryItem(textList.first())
             val historyList = preferencesManager.getHistoryList().first()
-            assertEquals(listOf("test"), historyList)
+            assertEquals(textList, historyList)
         }
 
     /** 既存の履歴に新しいアイテムを追加するテスト */
     @Test
     fun testAddNewToExisting() =
         runBlocking {
-            val initialItems = listOf("item1", "item2")
+            val initialItems = sampleHistoryList
             dataStore.edit { it[historyKey] = initialItems.joinToString(",") }
 
-            preferencesManager.saveHistoryItem("item3")
+            val newText = "newItem"
+            preferencesManager.saveHistoryItem(newText)
             val historyList = preferencesManager.getHistoryList().first()
-            assertEquals(initialItems + "item3", historyList)
+            assertEquals(initialItems + newText, historyList)
         }
 
     /** 履歴が最大数に達した時に最も古いアイテムを削除するテスト */
@@ -74,9 +77,10 @@ class PreferencesManagerTest {
             val initialItems = List(MAX_HISTORY_SIZE) { "item$it" }
             dataStore.edit { it[historyKey] = initialItems.joinToString(",") }
 
-            preferencesManager.saveHistoryItem("newItem")
+            val newText = "newItem"
+            preferencesManager.saveHistoryItem(newText)
             val historyList = preferencesManager.getHistoryList().first()
-            assertEquals(initialItems.drop(1) + "newItem", historyList)
+            assertEquals(initialItems.drop(1) + newText, historyList)
             assertEquals(MAX_HISTORY_SIZE, historyList.size)
         }
 
@@ -84,10 +88,11 @@ class PreferencesManagerTest {
     @Test
     fun testPreventDuplicates() =
         runBlocking {
-            val initialItems = listOf("item1", "item2", "item3")
+            val initialItems = sampleHistoryList
             dataStore.edit { it[historyKey] = initialItems.joinToString(",") }
 
-            preferencesManager.saveHistoryItem("item2")
+            val existingItem = initialItems.first()
+            preferencesManager.saveHistoryItem(existingItem)
             val historyList = preferencesManager.getHistoryList().first()
             assertEquals(initialItems, historyList)
         }
@@ -96,7 +101,7 @@ class PreferencesManagerTest {
     @Test
     fun testGetHistory() =
         runBlocking {
-            val expectedItems = listOf("item1", "item2", "item3")
+            val expectedItems = sampleHistoryList
             dataStore.edit { it[historyKey] = expectedItems.joinToString(",") }
 
             val historyList = preferencesManager.getHistoryList().first()
@@ -115,7 +120,7 @@ class PreferencesManagerTest {
     @Test
     fun testClearHistory() =
         runBlocking {
-            val initialItems = listOf("item1", "item2", "item3")
+            val initialItems = sampleHistoryList
             dataStore.edit { it[historyKey] = initialItems.joinToString(",") }
 
             preferencesManager.clearHistory()

--- a/app/src/test/java/com/example/gourmetsearchercompose/repository/KeyWordHistoryRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/repository/KeyWordHistoryRepositoryImplTest.kt
@@ -1,6 +1,8 @@
 package com.example.gourmetsearchercompose.repository
 
 import com.example.gourmetsearchercompose.manager.PreferencesManager
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -30,7 +32,6 @@ class KeyWordHistoryRepositoryImplTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     /** 各テスト前の準備 */
-
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -46,7 +47,7 @@ class KeyWordHistoryRepositoryImplTest {
     @Test
     fun testSaveHistoryItem() =
         runTest {
-            val input = "keyword 1"
+            val input = KEYWORD
             keyWordHistoryRepository.saveHistoryItem(input)
             verify(preferences).saveHistoryItem(input)
         }
@@ -55,7 +56,7 @@ class KeyWordHistoryRepositoryImplTest {
     @Test
     fun testGetHistoryList() =
         runTest {
-            val expectedHistoryList = listOf("keyword1", "keyword2", "keyword3")
+            val expectedHistoryList = sampleHistoryList
             `when`(preferences.getHistoryList()).thenReturn(flowOf(expectedHistoryList))
             val actualHistoryList = keyWordHistoryRepository.getHistoryList()
             actualHistoryList.collect {

--- a/app/src/test/java/com/example/gourmetsearchercompose/repository/RestaurantListRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/repository/RestaurantListRepositoryImplTest.kt
@@ -2,18 +2,10 @@ package com.example.gourmetsearchercompose.repository
 
 import com.example.gourmetsearchercompose.BuildConfig
 import com.example.gourmetsearchercompose.manager.CacheManager
-import com.example.gourmetsearchercompose.model.api.BudgetData
-import com.example.gourmetsearchercompose.model.api.GenreData
-import com.example.gourmetsearchercompose.model.api.LargeAreaData
-import com.example.gourmetsearchercompose.model.api.PCData
-import com.example.gourmetsearchercompose.model.api.PhotoData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
 import com.example.gourmetsearchercompose.model.api.Results
-import com.example.gourmetsearchercompose.model.api.Shops
-import com.example.gourmetsearchercompose.model.api.SmallAreaData
-import com.example.gourmetsearchercompose.model.api.Urls
-import com.example.gourmetsearchercompose.model.data.CurrentLocation
-import com.example.gourmetsearchercompose.model.data.SearchTerms
 import com.example.gourmetsearchercompose.service.HotPepperGourmetApiService
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -42,35 +34,9 @@ class RestaurantListRepositoryImplTest {
 
     private lateinit var restaurantRepository: RestaurantRepository
 
-    private val mockSearchTerms = SearchTerms(
-        "keyword",
-        CurrentLocation(35.0, 139.0),
-        1
-    )
+    private val responseFormat = "json"
 
-    private val mockResponse =
-        Response.success(
-            RestaurantList(
-                Results(
-                    listOf(
-                        Shops(
-                            "Restaurant",
-                            "Address",
-                            "Station",
-                            LargeAreaData("Large Area"),
-                            SmallAreaData("Small Area"),
-                            GenreData("Genre"),
-                            BudgetData("Budget"),
-                            "Access",
-                            Urls("URL"),
-                            PhotoData(PCData("Photo URL")),
-                            "Open",
-                            "Close",
-                        ),
-                    ),
-                ),
-            ),
-        )
+    private val mockResponse = Response.success(sampleResponseData)
 
     /** 各テスト前の準備 */
     @Before
@@ -82,11 +48,11 @@ class RestaurantListRepositoryImplTest {
     @Test
     fun testExecuteCacheHit() =
         runBlocking {
-            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(mockResponse)
+            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(mockResponse)
 
-            val result = restaurantRepository.searchRestaurantRepository(mockSearchTerms)
+            val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
-            verify(mockCacheManager).get(mockSearchTerms)
+            verify(mockCacheManager).get(sampleSearchTerms)
             verify(mockService, never()).searchRestaurants(
                 anyString(),
                 anyString(),
@@ -102,7 +68,7 @@ class RestaurantListRepositoryImplTest {
     @Test
     fun testExecuteCacheMiss() =
         runBlocking {
-            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(null)
+            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(null)
             `when`(
                 mockService.searchRestaurants(
                     anyString(),
@@ -114,18 +80,21 @@ class RestaurantListRepositoryImplTest {
                 ),
             ).thenReturn(mockResponse)
 
-            val result = restaurantRepository.searchRestaurantRepository(mockSearchTerms)
+            val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
-            verify(mockCacheManager).get(mockSearchTerms)
-            verify(mockService).searchRestaurants(
-                BuildConfig.API_KEY,
-                mockSearchTerms.keyword,
-                mockSearchTerms.location.latitude,
-                mockSearchTerms.location.longitude,
-                mockSearchTerms.range,
-                "json",
-            )
-            verify(mockCacheManager).put(mockSearchTerms, mockResponse)
+            verify(mockCacheManager).get(sampleSearchTerms)
+
+            with(sampleSearchTerms) {
+                verify(mockService).searchRestaurants(
+                    BuildConfig.API_KEY,
+                    keyword,
+                    location.latitude,
+                    location.longitude,
+                    range,
+                    responseFormat
+                )
+            }
+            verify(mockCacheManager).put(sampleSearchTerms, mockResponse)
             assertEquals(mockResponse, result)
         }
 
@@ -133,7 +102,7 @@ class RestaurantListRepositoryImplTest {
     @Test
     fun testExecuteWithException() =
         runBlocking {
-            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(null)
+            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(null)
             `when`(
                 mockService.searchRestaurants(
                     anyString(),
@@ -145,18 +114,21 @@ class RestaurantListRepositoryImplTest {
                 ),
             ).thenThrow(RuntimeException::class.java)
 
-            val result = restaurantRepository.searchRestaurantRepository(mockSearchTerms)
+            val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
-            verify(mockCacheManager).get(mockSearchTerms)
-            verify(mockService).searchRestaurants(
-                BuildConfig.API_KEY,
-                mockSearchTerms.keyword,
-                mockSearchTerms.location.latitude,
-                mockSearchTerms.location.longitude,
-                mockSearchTerms.range,
-                "json",
-            )
-            verify(mockCacheManager, never()).put(mockSearchTerms, mockResponse)
+            verify(mockCacheManager).get(sampleSearchTerms)
+            with(sampleSearchTerms) {
+                verify(mockService).searchRestaurants(
+                    BuildConfig.API_KEY,
+                    keyword,
+                    location.latitude,
+                    location.longitude,
+                    range,
+                    responseFormat,
+                )
+            }
+
+            verify(mockCacheManager, never()).put(sampleSearchTerms, mockResponse)
             assertNull(result)
         }
 
@@ -165,7 +137,7 @@ class RestaurantListRepositoryImplTest {
     fun testExecuteWithEmptyResponse() =
         runBlocking {
             val emptyResponse = Response.success(RestaurantList(Results(emptyList())))
-            `when`(mockCacheManager.get(mockSearchTerms)).thenReturn(null)
+            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(null)
             `when`(
                 mockService.searchRestaurants(
                     anyString(),
@@ -177,18 +149,20 @@ class RestaurantListRepositoryImplTest {
                 ),
             ).thenReturn(emptyResponse)
 
-            val result = restaurantRepository.searchRestaurantRepository(mockSearchTerms)
+            val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
-            verify(mockCacheManager).get(mockSearchTerms)
-            verify(mockService).searchRestaurants(
-                BuildConfig.API_KEY,
-                mockSearchTerms.keyword,
-                mockSearchTerms.location.latitude,
-                mockSearchTerms.location.longitude,
-                mockSearchTerms.range,
-                "json",
-            )
-            verify(mockCacheManager).put(mockSearchTerms, emptyResponse)
+            verify(mockCacheManager).get(sampleSearchTerms)
+            with(sampleSearchTerms) {
+                verify(mockService).searchRestaurants(
+                    BuildConfig.API_KEY,
+                    keyword,
+                    location.latitude,
+                    location.longitude,
+                    range,
+                    responseFormat,
+                )
+            }
+            verify(mockCacheManager).put(sampleSearchTerms, emptyResponse)
             assertEquals(emptyResponse, result)
         }
 }

--- a/app/src/test/java/com/example/gourmetsearchercompose/repository/RestaurantListRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/repository/RestaurantListRepositoryImplTest.kt
@@ -2,7 +2,7 @@ package com.example.gourmetsearchercompose.repository
 
 import com.example.gourmetsearchercompose.BuildConfig
 import com.example.gourmetsearchercompose.manager.CacheManager
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleAPIResponse
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
 import com.example.gourmetsearchercompose.model.api.Results
@@ -36,8 +36,6 @@ class RestaurantListRepositoryImplTest {
 
     private val responseFormat = "json"
 
-    private val mockResponse = Response.success(sampleResponseData)
-
     /** 各テスト前の準備 */
     @Before
     fun setup() {
@@ -48,7 +46,7 @@ class RestaurantListRepositoryImplTest {
     @Test
     fun testExecuteCacheHit() =
         runBlocking {
-            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(mockResponse)
+            `when`(mockCacheManager.get(sampleSearchTerms)).thenReturn(sampleAPIResponse)
 
             val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
@@ -61,7 +59,7 @@ class RestaurantListRepositoryImplTest {
                 anyInt(),
                 anyString(),
             )
-            assertEquals(mockResponse, result)
+            assertEquals(sampleAPIResponse, result)
         }
 
     /** キャッシュミス時のテスト */
@@ -78,7 +76,7 @@ class RestaurantListRepositoryImplTest {
                     anyInt(),
                     anyString(),
                 ),
-            ).thenReturn(mockResponse)
+            ).thenReturn(sampleAPIResponse)
 
             val result = restaurantRepository.searchRestaurantRepository(sampleSearchTerms)
 
@@ -94,8 +92,8 @@ class RestaurantListRepositoryImplTest {
                     responseFormat
                 )
             }
-            verify(mockCacheManager).put(sampleSearchTerms, mockResponse)
-            assertEquals(mockResponse, result)
+            verify(mockCacheManager).put(sampleSearchTerms, sampleAPIResponse)
+            assertEquals(sampleAPIResponse, result)
         }
 
     /** API例外時のテスト */
@@ -128,7 +126,7 @@ class RestaurantListRepositoryImplTest {
                 )
             }
 
-            verify(mockCacheManager, never()).put(sampleSearchTerms, mockResponse)
+            verify(mockCacheManager, never()).put(sampleSearchTerms, sampleAPIResponse)
             assertNull(result)
         }
 

--- a/app/src/test/java/com/example/gourmetsearchercompose/repository/SearchLocationRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/repository/SearchLocationRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.example.gourmetsearchercompose.repository
 
 import android.location.Location
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.data.CurrentLocation
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.Priority
@@ -42,10 +43,7 @@ class SearchLocationRepositoryImplTest {
     @Test
     fun testGetLocationSuccess() =
         runTest {
-            val expectedLocation = CurrentLocation(
-                35.6895,
-                139.6917
-            )
+            val expectedLocation = sampleSearchTerms.location
             val mockLocation = mock<Location>()
             `when`(mockLocation.latitude).thenReturn(expectedLocation.latitude)
             `when`(mockLocation.longitude).thenReturn(expectedLocation.longitude)

--- a/app/src/test/java/com/example/gourmetsearchercompose/usecase/keywordhistory/GetKeyWordHistoryUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/usecase/keywordhistory/GetKeyWordHistoryUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.example.gourmetsearchercompose.usecase.keywordhistory
 
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.repository.KeyWordHistoryRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,7 +47,7 @@ class GetKeyWordHistoryUseCaseTest {
     @Test
     fun testInvokeReturnsHistoryList() =
         runTest {
-            val expectedHistoryList = listOf("keyword1", "keyword2", "keyword3")
+            val expectedHistoryList = sampleHistoryList
             `when`(keyWordHistoryRepository.getHistoryList()).thenReturn(flowOf(expectedHistoryList))
 
             val result = getKeyWordHistoryUseCase()

--- a/app/src/test/java/com/example/gourmetsearchercompose/usecase/keywordhistory/SaveKeyWordHistoryUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/usecase/keywordhistory/SaveKeyWordHistoryUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.example.gourmetsearchercompose.usecase.keywordhistory
 
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
 import com.example.gourmetsearchercompose.repository.KeyWordHistoryRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -43,7 +44,7 @@ class SaveKeyWordHistoryUseCaseTest {
     @Test
     fun testInvokeCallsSaveHistoryItem() =
         runTest {
-            val keyword = "testKeyword"
+            val keyword = KEYWORD
 
             saveKeyWordHistoryUseCase(keyword)
 

--- a/app/src/test/java/com/example/gourmetsearchercompose/usecase/location/GetCurrentLocationUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/usecase/location/GetCurrentLocationUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.example.gourmetsearchercompose.usecase.location
 
 import android.location.Location
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.data.CurrentLocation
 import com.example.gourmetsearchercompose.repository.SearchLocationRepository
 import kotlinx.coroutines.runBlocking
@@ -27,7 +28,7 @@ class GetCurrentLocationUseCaseTest {
     @Test
     fun testInvokeReturnsLocationSuccessful() =
         runBlocking {
-            val expectedLocation = CurrentLocation(35.6895, 139.6917)
+            val expectedLocation = sampleSearchTerms.location
             val mockLocation = mock<Location>()
             `when`(mockLocation.latitude).thenReturn(expectedLocation.latitude)
             `when`(mockLocation.longitude).thenReturn(expectedLocation.longitude)

--- a/app/src/test/java/com/example/gourmetsearchercompose/usecase/network/GetRestaurantListUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/usecase/network/GetRestaurantListUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.example.gourmetsearchercompose.usecase.network
 
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleAPIResponse
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.repository.RestaurantRepository
 import kotlinx.coroutines.runBlocking
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
-import retrofit2.Response
 
 /** GetHotPepperDataUseCaseのユニットテストクラス */
 @RunWith(MockitoJUnitRunner::class)
@@ -23,21 +22,16 @@ class GetRestaurantListUseCaseTest {
     @InjectMocks
     private lateinit var getRestaurantUseCase: GetRestaurantUseCase
 
-    private val mockResponse =
-        Response.success(
-            sampleResponseData
-        )
-
     /** 正しくAPIが呼び出された場合のテスト */
     @Test
     fun testInvokeReturnsSuccessful() =
         runBlocking {
             `when`(restaurantRepository.searchRestaurantRepository(sampleSearchTerms))
-                .thenReturn(mockResponse)
+                .thenReturn(sampleAPIResponse)
 
             val result = getRestaurantUseCase(sampleSearchTerms)
 
-            assertEquals(mockResponse, result)
+            assertEquals(sampleAPIResponse, result)
         }
 
     /** レスポンスがnullの場合のテスト */

--- a/app/src/test/java/com/example/gourmetsearchercompose/usecase/network/GetRestaurantListUseCaseTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/usecase/network/GetRestaurantListUseCaseTest.kt
@@ -1,17 +1,7 @@
 package com.example.gourmetsearchercompose.usecase.network
 
-import com.example.gourmetsearchercompose.model.api.BudgetData
-import com.example.gourmetsearchercompose.model.api.GenreData
-import com.example.gourmetsearchercompose.model.api.LargeAreaData
-import com.example.gourmetsearchercompose.model.api.PCData
-import com.example.gourmetsearchercompose.model.api.PhotoData
-import com.example.gourmetsearchercompose.model.api.RestaurantList
-import com.example.gourmetsearchercompose.model.api.Results
-import com.example.gourmetsearchercompose.model.api.Shops
-import com.example.gourmetsearchercompose.model.api.SmallAreaData
-import com.example.gourmetsearchercompose.model.api.Urls
-import com.example.gourmetsearchercompose.model.data.CurrentLocation
-import com.example.gourmetsearchercompose.model.data.SearchTerms
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.repository.RestaurantRepository
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -35,42 +25,17 @@ class GetRestaurantListUseCaseTest {
 
     private val mockResponse =
         Response.success(
-            RestaurantList(
-                Results(
-                    listOf(
-                        Shops(
-                            "Restaurant",
-                            "Address",
-                            "Station",
-                            LargeAreaData("Large Area"),
-                            SmallAreaData("Small Area"),
-                            GenreData("Genre"),
-                            BudgetData("Budget"),
-                            "Access",
-                            Urls("URL"),
-                            PhotoData(PCData("Photo URL")),
-                            "Open",
-                            "Close",
-                        ),
-                    ),
-                ),
-            ),
+            sampleResponseData
         )
-
-    private val mockSearchTerms = SearchTerms(
-        "",
-        CurrentLocation(0.0, 0.0),
-        1
-    )
 
     /** 正しくAPIが呼び出された場合のテスト */
     @Test
     fun testInvokeReturnsSuccessful() =
         runBlocking {
-            `when`(restaurantRepository.searchRestaurantRepository(mockSearchTerms))
+            `when`(restaurantRepository.searchRestaurantRepository(sampleSearchTerms))
                 .thenReturn(mockResponse)
 
-            val result = getRestaurantUseCase(mockSearchTerms)
+            val result = getRestaurantUseCase(sampleSearchTerms)
 
             assertEquals(mockResponse, result)
         }
@@ -79,10 +44,10 @@ class GetRestaurantListUseCaseTest {
     @Test
     fun testInvokeReturnsNull() =
         runBlocking {
-            `when`(restaurantRepository.searchRestaurantRepository(mockSearchTerms))
+            `when`(restaurantRepository.searchRestaurantRepository(sampleSearchTerms))
                 .thenReturn(null)
 
-            val result = getRestaurantUseCase(mockSearchTerms)
+            val result = getRestaurantUseCase(sampleSearchTerms)
 
             assertNull(result)
         }
@@ -91,14 +56,15 @@ class GetRestaurantListUseCaseTest {
     @Test
     fun testInvokeReturnsError() =
         runBlocking {
-            `when`(restaurantRepository.searchRestaurantRepository(mockSearchTerms))
-                .thenThrow(RuntimeException("API Error"))
+            val errorMessage = "API Error"
+            `when`(restaurantRepository.searchRestaurantRepository(sampleSearchTerms))
+                .thenThrow(RuntimeException(errorMessage))
 
             try {
-                getRestaurantUseCase(mockSearchTerms)
+                getRestaurantUseCase(sampleSearchTerms)
                 assert(false)
             } catch (e: RuntimeException) {
-                assert(e.message == "API Error")
+                assert(e.message == errorMessage)
             }
         }
 }

--- a/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/InputKeyWordViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/InputKeyWordViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.example.gourmetsearchercompose.viewmodel
 
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.KEYWORD
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleHistoryList
 import com.example.gourmetsearchercompose.usecase.keywordhistory.ClearKeyWordHistoryUseCase
 import com.example.gourmetsearchercompose.usecase.keywordhistory.GetKeyWordHistoryUseCase
 import com.example.gourmetsearchercompose.usecase.keywordhistory.SaveKeyWordHistoryUseCase
@@ -51,7 +53,7 @@ class InputKeyWordViewModelTest {
     /** テキストの更新が正しく行われることを確認するテスト */
     @Test
     fun testUpdateWithNewValue() = runTest {
-        val newText = "Hello, World!"
+        val newText = KEYWORD
 
         viewModel =
             InputKeyWordViewModel(
@@ -83,8 +85,8 @@ class InputKeyWordViewModelTest {
     /** 複数回の更新が正しく行われることを確認するテスト */
     @Test
     fun testMultipleUpdates() = runTest {
-        val firstText = "First"
-        val secondText = "Second"
+        val firstText = sampleHistoryList[0]
+        val secondText = sampleHistoryList[1]
 
         viewModel =
             InputKeyWordViewModel(
@@ -116,7 +118,7 @@ class InputKeyWordViewModelTest {
     @Test
     fun testLoadHistoryOnInit() =
         runTest {
-            val testHistory = listOf("test1", "test2")
+            val testHistory = sampleHistoryList
             `when`(getHistoryListUseCase()).thenReturn(flowOf(testHistory))
 
             viewModel =
@@ -133,7 +135,7 @@ class InputKeyWordViewModelTest {
     @Test
     fun testSaveHistoryItemUpdatesHistoryList() =
         runTest {
-            val updatedHistory = listOf("test1", "test2", "test3")
+            val updatedHistory = sampleHistoryList
 
             `when`(getHistoryListUseCase()).thenReturn(
                 flowOf(updatedHistory),
@@ -147,9 +149,10 @@ class InputKeyWordViewModelTest {
                     clearHistoryUseCase,
                 )
 
-            viewModel.saveHistoryItem("test3")
+            val newItem = "newItem"
+            viewModel.saveHistoryItem(newItem)
 
-            verify(saveHistoryItemUseCase).invoke("test3")
+            verify(saveHistoryItemUseCase).invoke(newItem)
             assertEquals(updatedHistory.reversed(), viewModel.historyListData.value)
         }
 
@@ -157,7 +160,7 @@ class InputKeyWordViewModelTest {
     @Test
     fun testSaveAndGetHistoryItem() =
         runTest {
-            val testHistory = listOf("test1", "test2")
+            val testHistory = sampleHistoryList
             `when`(getHistoryListUseCase()).thenReturn(flowOf(testHistory))
             `when`(saveHistoryItemUseCase(anyString())).thenReturn(Unit)
 
@@ -168,9 +171,10 @@ class InputKeyWordViewModelTest {
                     clearHistoryUseCase,
                 )
 
-            viewModel.saveHistoryItem("test3")
+            val newItem = "newItem"
+            viewModel.saveHistoryItem(newItem)
 
-            verify(saveHistoryItemUseCase).invoke("test3")
+            verify(saveHistoryItemUseCase).invoke(newItem)
             assertEquals(testHistory.reversed(), viewModel.historyListData.value)
         }
 

--- a/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantDetailViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.example.gourmetsearchercompose.viewmodel
 
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleRestaurantList
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +17,7 @@ class RestaurantDetailViewModelTest {
     /** 地図を開く機能のテスト */
     @Test
     fun testOpenMap() {
-        val address = "東京都渋谷区道玄坂1-2-3"
+        val address = sampleRestaurantList.first().address
         val encodedAddress = URLEncoder.encode(address, "UTF-8")
 
         viewModel.openMap(address)
@@ -35,7 +36,7 @@ class RestaurantDetailViewModelTest {
     /** URLを開く機能のテスト */
     @Test
     fun testOpenUrl() {
-        val url = "https://example.com"
+        val url = sampleRestaurantList.first().url.pc
 
         viewModel.openUrl(url)
 

--- a/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantListViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantListViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.example.gourmetsearchercompose.viewmodel
 
-import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleAPIResponse
 import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
 import com.example.gourmetsearchercompose.model.api.Results
@@ -38,8 +38,6 @@ class RestaurantListViewModelTest {
     @InjectMocks
     private lateinit var viewModel: RestaurantListViewModel
 
-    private val mockResponse = Response.success(sampleResponseData)
-
     private val mockEmptyResponse =
         RestaurantList(
             Results(
@@ -63,10 +61,10 @@ class RestaurantListViewModelTest {
     @Test
     fun testSearchRestaurantsSuccess() =
         runTest {
-            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(mockResponse)
+            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(sampleAPIResponse)
             viewModel.searchRestaurants(sampleSearchTerms)
 
-            val shops = mockResponse.body()?.results?.shops?.map { it.toDomain() }
+            val shops = sampleAPIResponse.body()?.results?.shops?.map { it.toDomain() }
             assertEquals(shops, viewModel.shops.value)
             assertEquals(
                 SearchState.SUCCESS,

--- a/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantListViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/RestaurantListViewModelTest.kt
@@ -1,17 +1,10 @@
 package com.example.gourmetsearchercompose.viewmodel
 
-import com.example.gourmetsearchercompose.model.api.BudgetData
-import com.example.gourmetsearchercompose.model.api.GenreData
-import com.example.gourmetsearchercompose.model.api.LargeAreaData
-import com.example.gourmetsearchercompose.model.api.PCData
-import com.example.gourmetsearchercompose.model.api.PhotoData
+import com.example.gourmetsearchercompose.mock.MockRestaurantData.sampleResponseData
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.model.api.RestaurantList
 import com.example.gourmetsearchercompose.model.api.Results
 import com.example.gourmetsearchercompose.model.api.Shops
-import com.example.gourmetsearchercompose.model.api.SmallAreaData
-import com.example.gourmetsearchercompose.model.api.Urls
-import com.example.gourmetsearchercompose.model.data.CurrentLocation
-import com.example.gourmetsearchercompose.model.data.SearchTerms
 import com.example.gourmetsearchercompose.model.domain.toDomain
 import com.example.gourmetsearchercompose.state.SearchState
 import com.example.gourmetsearchercompose.usecase.network.GetRestaurantUseCase
@@ -45,39 +38,13 @@ class RestaurantListViewModelTest {
     @InjectMocks
     private lateinit var viewModel: RestaurantListViewModel
 
-    private val mockResponse =
-        RestaurantList(
-            Results(
-                listOf(
-                    Shops(
-                        "Restaurant",
-                        "Address",
-                        "Station",
-                        LargeAreaData("Large Area"),
-                        SmallAreaData("Small Area"),
-                        GenreData("Genre"),
-                        BudgetData("Budget"),
-                        "Access",
-                        Urls("URL"),
-                        PhotoData(PCData("Photo URL")),
-                        "Open",
-                        "Close",
-                    ),
-                ),
-            ),
-        )
+    private val mockResponse = Response.success(sampleResponseData)
+
     private val mockEmptyResponse =
         RestaurantList(
             Results(
                 emptyList(),
             ),
-        )
-
-    private val mockSearchTerms =
-        SearchTerms(
-            "keyword",
-            CurrentLocation(0.0, 0.0),
-            1,
         )
 
     /** 各テスト前の準備 */
@@ -96,10 +63,10 @@ class RestaurantListViewModelTest {
     @Test
     fun testSearchRestaurantsSuccess() =
         runTest {
-            `when`(getRestaurantUseCase(mockSearchTerms)).thenReturn(Response.success(mockResponse))
-            viewModel.searchRestaurants(mockSearchTerms)
+            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(mockResponse)
+            viewModel.searchRestaurants(sampleSearchTerms)
 
-            val shops = mockResponse.results.shops.map { it.toDomain() }
+            val shops = mockResponse.body()?.results?.shops?.map { it.toDomain() }
             assertEquals(shops, viewModel.shops.value)
             assertEquals(
                 SearchState.SUCCESS,
@@ -111,9 +78,9 @@ class RestaurantListViewModelTest {
     @Test
     fun testSearchRestaurantsNetworkError() =
         runTest {
-            `when`(getRestaurantUseCase(mockSearchTerms)).thenReturn(null)
+            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(null)
 
-            viewModel.searchRestaurants(mockSearchTerms)
+            viewModel.searchRestaurants(sampleSearchTerms)
 
             assertEquals(SearchState.NETWORK_ERROR, viewModel.searchState.value)
         }
@@ -122,13 +89,13 @@ class RestaurantListViewModelTest {
     @Test
     fun testSearchRestaurantsEmptyResponse() =
         runTest {
-            `when`(getRestaurantUseCase(mockSearchTerms)).thenReturn(
+            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(
                 Response.success(
                     mockEmptyResponse
                 )
             )
 
-            viewModel.searchRestaurants(mockSearchTerms)
+            viewModel.searchRestaurants(sampleSearchTerms)
             val shops = mockEmptyResponse.results.shops.map { it.toDomain() }
             assertEquals(emptyList<Shops>(), shops)
             assertEquals(SearchState.EMPTY_RESULT, viewModel.searchState.value)
@@ -139,11 +106,11 @@ class RestaurantListViewModelTest {
     fun testRetrySearch() =
         runTest {
             val mockResponse = mock<Response<RestaurantList>>()
-            `when`(getRestaurantUseCase(mockSearchTerms)).thenReturn(mockResponse)
+            `when`(getRestaurantUseCase(sampleSearchTerms)).thenReturn(mockResponse)
 
-            viewModel.searchRestaurants(mockSearchTerms)
+            viewModel.searchRestaurants(sampleSearchTerms)
             viewModel.retrySearch()
 
-            verify(getRestaurantUseCase, times(2)).invoke(mockSearchTerms)
+            verify(getRestaurantUseCase, times(2)).invoke(sampleSearchTerms)
         }
 }

--- a/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/SearchLocationViewModelTest.kt
+++ b/app/src/test/java/com/example/gourmetsearchercompose/viewmodel/SearchLocationViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.example.gourmetsearchercompose.viewmodel
 
 import android.location.Location
-import com.example.gourmetsearchercompose.model.data.CurrentLocation
+import com.example.gourmetsearchercompose.mock.MockSearchTerms.sampleSearchTerms
 import com.example.gourmetsearchercompose.state.LocationSearchState
 import com.example.gourmetsearchercompose.usecase.location.GetCurrentLocationUseCase
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +50,7 @@ class SearchLocationViewModelTest {
     @Test
     fun testGetLocationSuccess() =
         runTest {
-            val expectedLocation = CurrentLocation(34.7010289, 135.4955003)
+            val expectedLocation = sampleSearchTerms.location
             val mockLocation = mock<Location>()
             `when`(mockLocation.latitude).thenReturn(expectedLocation.latitude)
             `when`(mockLocation.longitude).thenReturn(expectedLocation.longitude)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ espressoCore = "3.6.1"
 immutable = "0.3.8"
 kotlinxCoroutinesTest = "1.10.1"
 kotlinxSerializationJson = "1.7.3"
-mockitoCore = "5.14.2"
+mockito = "5.14.2"
 navigation = "2.8.5"
 junit = "4.13.2"
 leakcanary = "2.14"
@@ -82,7 +82,7 @@ leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.re
 #Unit Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 dagger-hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "dagger" }
-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 androidx-runner = { module = "androidx.test:runner", version.ref = "runnerVersion" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }


### PR DESCRIPTION
## Issue
- #157

## 現状の問題点
- テストの中で同じモックデータを複数箇所で定義していた問題がありました。

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- モックデータを定義し、そこから使うように変更しました。

## 参考リンク (任意)
- 

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
