### PR TITLE
UIのテキストカラーを調整しました

### DIFF
--- a/feature-keyword/src/main/java/com/example/feature_keyword/component/textfield/CustomTextField.kt
+++ b/feature-keyword/src/main/java/com/example/feature_keyword/component/textfield/CustomTextField.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -14,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.Blue
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -51,7 +51,7 @@ fun CustomTextField(
             .fillMaxWidth()
             .testTag("searchTextField"),
         colors = TextFieldDefaults.colors(
-            cursorColor = Blue,
+            cursorColor = MaterialTheme.colorScheme.primary,
             focusedContainerColor = Color.Transparent,
             unfocusedContainerColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent,

--- a/shared-ui/src/main/java/com/example/shared_ui/CustomOutlinedButton.kt
+++ b/shared-ui/src/main/java/com/example/shared_ui/CustomOutlinedButton.kt
@@ -3,12 +3,12 @@ package com.example.shared_ui
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.Blue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -25,7 +25,7 @@ fun CustomOutlinedButton(
     @StringRes text: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    textColor: Color = Blue,
+    textColor: Color = MaterialTheme.colorScheme.primary,
     icon: ImageVector? = null
 ) {
     OutlinedButton(

--- a/shared-ui/src/main/java/com/example/shared_ui/Dialog.kt
+++ b/shared-ui/src/main/java/com/example/shared_ui/Dialog.kt
@@ -2,9 +2,9 @@ package com.example.shared_ui
 
 import androidx.annotation.StringRes
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color.Companion.Blue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
 
@@ -31,7 +31,7 @@ fun Dialog(
             CustomOutlinedButton(
                 text = R.string.common_ok,
                 onClick = onConfirmClick,
-                textColor = Blue
+                textColor = MaterialTheme.colorScheme.primary
             )
         },
         // OKボタン以外ないので何もしない

--- a/shared-ui/src/main/java/com/example/shared_ui/LoadingContent.kt
+++ b/shared-ui/src/main/java/com/example/shared_ui/LoadingContent.kt
@@ -3,10 +3,10 @@ package com.example.shared_ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.Blue
 
 /**
  * ローディングコンテンツ
@@ -20,6 +20,6 @@ fun LoadingContent(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator(color = Blue)
+        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
     }
 }


### PR DESCRIPTION
## Issue
- #170 

## 現状の問題点
- UIがダークモードの時に見ずらい問題
- 

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- ![Color.Blue](https://via.placeholder.com/15/00FF/000000?text=+) `Color.Blue`から```MaterialTheme.colorScheme.primary```に変更しました


## 参考リンク (任意)
- 

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
