### PR TITLE
バージョンを更新

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 # SDK Versions
 compileSdk = "35"
 minSdk = "32"
-runtime = "1.7.6"
 targetSdk = "35"
 
 # JVM Versions
@@ -12,12 +11,13 @@ kotlin-jvm = "17"
 accompanistPermissions = "0.37.0"
 agp = "8.8.0"
 coil = "2.7.0"
+runtime = "1.7.6"
 coreTesting = "2.2.0"
 datastorePreferences = "1.1.2"
 detektFormatting = "1.23.7"
 detektVersion = "0.4.22"
-kotlin = "2.0.21"
-ksp = "2.0.21-1.0.27"
+kotlin = "2.1.0"
+ksp = "2.1.0-1.0.29"
 coreKtx = "1.15.0"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"


### PR DESCRIPTION
## Issue
- #186 

## 現状の問題点
-  #177 ではkotlinが2.0.21のままkspを2.1.0-1.0.29に更新しようとしていたため、ビルドエラーが起きていた。

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- kotlinを2.1.0に更新
- kspを2.1.0-1.0.29に更新

## 参考リンク (任意)
- 

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
