### PR TITLE
189 検索結果一覧画面のスクロールを保持するように変更

### DIFF
--- a/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantListContentTest.kt
+++ b/app/src/androidTest/java/com/example/gourmetsearchercompose/RestaurantListContentTest.kt
@@ -1,6 +1,7 @@
 package com.example.gourmetsearchercompose
 
 import android.content.Context
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -83,7 +84,8 @@ class RestaurantListContentTest {
         composeTestRule.setContent {
             RestaurantRow(
                 shops = sampleRestaurantList,
-                navigateToDetail = {}
+                navigateToDetail = {},
+                listState = rememberLazyListState()
             )
         }
 

--- a/feature-restaurant/src/main/java/com/example/feature_restaurant/restaurantlist/component/RestaurantListContent.kt
+++ b/feature-restaurant/src/main/java/com/example/feature_restaurant/restaurantlist/component/RestaurantListContent.kt
@@ -2,6 +2,7 @@ package com.example.feature_restaurant.restaurantlist.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,16 +30,21 @@ fun RestaurantListContent(
     onNavigateToDetail: (ShopsDomain) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+
     Box(
-        modifier = modifier
-            .fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.TopStart
     ) {
         when (searchState) {
             SearchState.LOADING -> LoadingContent()
 
             SearchState.SUCCESS -> shops?.let {
-                RestaurantRow(it, onNavigateToDetail)
+                RestaurantRow(
+                    shops = it,
+                    navigateToDetail = onNavigateToDetail,
+                    listState = listState
+                )
             }
 
             SearchState.EMPTY_RESULT -> ErrorContent(

--- a/feature-restaurant/src/main/java/com/example/feature_restaurant/restaurantlist/component/RestaurantRow.kt
+++ b/feature-restaurant/src/main/java/com/example/feature_restaurant/restaurantlist/component/RestaurantRow.kt
@@ -1,10 +1,13 @@
 package com.example.feature_restaurant.restaurantlist.component
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.feature_restaurant.domain.ShopsDomain
 import com.example.feature_restaurant.mock.MockRestaurantData.sampleRestaurantList
 import kotlinx.collections.immutable.ImmutableList
@@ -19,9 +22,14 @@ import kotlinx.collections.immutable.ImmutableList
 fun RestaurantRow(
     shops: ImmutableList<ShopsDomain>,
     navigateToDetail: (ShopsDomain) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    listState: LazyListState,
 ) {
-    LazyColumn(modifier = modifier) {
+    LazyColumn(
+        modifier = modifier,
+        state = listState,
+        contentPadding = PaddingValues(vertical = 8.dp)
+    ) {
         items(shops) { restaurant ->
             RestaurantItem(
                 restaurant = restaurant,
@@ -38,6 +46,7 @@ fun RestaurantRow(
 private fun PreviewRestaurantRow() {
     RestaurantRow(
         shops = sampleRestaurantList,
-        navigateToDetail = {}
+        navigateToDetail = {},
+        listState = LazyListState()
     )
 }


### PR DESCRIPTION
## Issue
- #189 

## 現状の問題点
- 詳細画面から検索結果一覧画面に戻ったときにスクロール位置がリセットされて使いにくい

## 概要 (必須)
<!-- 概要をここに記入してください。 -->
- RestaurantListContentに ```val listState = rememberLazyListState() ```を持たせるようにしました。
- RestaurantRowの引数で受け取り、LazyColumnの引数に代入しました。

## 参考リンク (任意)
- 

## スクリーンショット (任意)
|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
